### PR TITLE
feat: generate types.d.ts pre-build for JIT type support

### DIFF
--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,3 @@
+dist
+.nuxt
+node_modules

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "declaration": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src",
+    ".nuxt/types.d.ts"
+  ]
+}

--- a/src/build.ts
+++ b/src/build.ts
@@ -30,7 +30,7 @@ export async function buildModule (rootDir: string) {
         const buildRuntimeDir = resolve(ctx.options.rootDir, '.nuxt')
 
         // Load module meta
-        const moduleEntryPath = resolve(ctx.options.rootDir, 'src', 'module')
+        const moduleEntryPath = resolve(ctx.options.rootDir, 'src', 'module.ts')
         const moduleFn: NuxtModule<any> = await import(moduleEntryPath).then(r => r.default || r).catch((err) => {
           consola.error(err)
           consola.error('Cannot load module. Please check dist:', moduleEntryPath)


### PR DESCRIPTION
With adding support for Module Hooks type support, I found an issue with the current build process for the types. With the types only being generated post-build it's not possible to access them as part of the build, meaning that module authors can't use the types that are being augmented for them. This isn't a massive issue for the module options, but for the hooks it is.

Development types are stored in .nuxt folder, build types are still in the dist file.

This is required for ModuleHooks support, see https://github.com/harlan-zw/module-builder/pull/1