### PR TITLE
feat: ModuleHooks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,15 @@ This is the entrypoint for module definition.
 
 A default export using `defineNuxtModule` and `ModuleOptions` type export is expected.
 
-```js [src/module.ts]
+```ts [src/module.ts]
 import { defineNuxtModule } from '@nuxt/kit'
 
 export interface ModuleOptions {
   apiKey: string
+}
+
+export interface ModuleHooks {
+  'my-module:options': (options: ModuleOptions) => Promise<void>|void
 }
 
 export default defineNuxtModule<ModuleOptions>({

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,3 @@
+dist
+.nuxt
+node_modules

--- a/example/src/module.ts
+++ b/example/src/module.ts
@@ -4,6 +4,10 @@ export interface ModuleOptions {
   apiKey: string
 }
 
+export interface ModuleHooks {
+  'my-module:options': (options: ModuleOptions) => Promise<void>|void
+}
+
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'my-module',
@@ -12,5 +16,7 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     apiKey: null
   },
-  setup (_options, _nuxt) {}
+  async setup (_options, _nuxt) {
+    await _nuxt.callHook('my-module:options', _options)
+  }
 })

--- a/example/tsconfig.json
+++ b/example/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "target": "ESNext",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "esModuleInterop": true,
+    "declaration": true,
+    "types": [
+      "node"
+    ]
+  },
+  "include": [
+    "src",
+    ".nuxt/types.d.ts"
+  ]
+}

--- a/src/build.ts
+++ b/src/build.ts
@@ -58,15 +58,13 @@ export async function buildModule (rootDir: string) {
           }
         }
 
-        // Write development types
         const moduleFileContent = await fsp.readFile(moduleEntryPath, 'utf-8')
         // Hacky way to check that ModuleHooks has been defined
         typeAugmentations.hooks = !!moduleFileContent.match(HasModuleHooksTest)
-        // Write development types
         const relativeModulePath = relative(buildRuntimeDir, moduleEntryPath)
             // bit hacky, need a better way to remove extension
             .replace('.ts', '')
-        // Generate types
+        // Generate runtime types
         await writeTypes(buildRuntimeDir, relativeModulePath)
       },
       async 'rollup:done' (ctx) {

--- a/src/build.ts
+++ b/src/build.ts
@@ -30,7 +30,7 @@ export async function buildModule (rootDir: string) {
         const buildRuntimeDir = resolve(ctx.options.rootDir, '.nuxt')
 
         // Load module meta
-        const moduleEntryPath = resolve(ctx.options.rootDir, 'src', 'module')
+        const moduleEntryPath = resolve(ctx.options.rootDir, 'src', 'module.ts')
         const moduleFn: NuxtModule<any> = await import(moduleEntryPath).then(r => r.default || r).catch((err) => {
           consola.error(err)
           consola.error('Cannot load module. Please check dist:', moduleEntryPath)


### PR DESCRIPTION
See this PR first: https://github.com/nuxt/module-builder/pull/11, for a cleaner diff see https://github.com/nuxt/module-builder/pull/12/commits/842593ca9276327439f6a9066c9058dd02655f7f

Adds support for module authors to have their hook types augmented for them. This is keeping consistent with the ModuleOptions being augmented 