### PR TITLE
fix: win32 support

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -1,4 +1,5 @@
 import { existsSync, promises as fsp } from 'fs'
+import { pathToFileURL } from 'url'
 import { resolve } from 'pathe'
 import consola from 'consola'
 import type { ModuleMeta, NuxtModule } from '@nuxt/schema'
@@ -29,7 +30,9 @@ export async function buildModule (rootDir: string) {
 
         // Load module meta
         const moduleEntryPath = resolve(ctx.options.outDir, 'module.mjs')
-        const moduleFn: NuxtModule<any> = await import(moduleEntryPath).then(r => r.default || r).catch((err) => {
+        const moduleFn: NuxtModule<any> = await import(
+          pathToFileURL(moduleEntryPath).toString()
+        ).then(r => r.default || r).catch((err) => {
           consola.error(err)
           consola.error('Cannot load module. Please check dist:', moduleEntryPath)
           return null

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,4 +1,4 @@
-#!/bin/env node
+#!/usr/bin/env node
 
 /* eslint-disable no-console */
 import mri from 'mri'


### PR DESCRIPTION
Hey it's me ☺️

So here are two fixes:

## fix: incorrect hashbang for cli (2f8dc6f)

<details>
<summary>With previous hashbang <code>#!/bin/env node</code></summary>
<br />

NPM generates the following at `~/node_modules/.bin/nuxt-module-build.cmd` which is invalid (`/bin/env` doesn't exist on Windows and path's using POSIX):

```bash
@ECHO off
GOTO start
:find_dp0
SET dp0=%~dp0
EXIT /b
:start
SETLOCAL
CALL :find_dp0

IF EXIST "%dp0%\/bin/env.exe" (
  SET "_prog=%dp0%\/bin/env.exe"
) ELSE (
  SET "_prog=/bin/env"
  SET PATHEXT=%PATHEXT:;.JS;=;%
)

endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%" node "%dp0%\..\@nuxt\module-builder\dist\cli.mjs" %*
```

</details>

<details>
<summary>With the new "regular" (it's on the on <a href="https://github.com/nuxt/framework/blob/main/packages/nuxi/bin/nuxi.mjs#L1">nuxi</a>) hashbang <code>#!/usr/bin/env node</code></summary>
<br />

NPM generates the following at `~/node_modules/.bin/nuxt-module-build.cmd` which is valid:

```bash
@ECHO off
GOTO start
:find_dp0
SET dp0=%~dp0
EXIT /b
:start
SETLOCAL
CALL :find_dp0

IF EXIST "%dp0%\node.exe" (
  SET "_prog=%dp0%\node.exe"
) ELSE (
  SET "_prog=node"
  SET PATHEXT=%PATHEXT:;.JS;=;%
)

endLocal & goto #_undefined_# 2>NUL || title %COMSPEC% & "%_prog%"  "%dp0%\..\@nuxt\module-builder\dist\cli.mjs" %*
```

</details>

## fix: esm loader requires file or data url (67f6776)

<details>
<summary>Before (erroring)</summary>
<br />

![image](https://user-images.githubusercontent.com/25330882/149137734-7ec7400b-faa1-4017-9073-bdd8660b7f61.png)
</details>

<details>
<summary>After (success)</summary>
<br />

![image](https://user-images.githubusercontent.com/25330882/149137516-659d82a5-104f-46d1-b1b8-1e5fde112212.png)
</details>

See: https://nodejs.org/api/errors.html#err_unsupported_esm_url_scheme

Let me know if anything 🙏