### PR TITLE
feat: support `ModuleRuntimeConfig` and `ModulePublicRuntimeConfig` type exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ export interface ModuleHooks {
   'my-module:init': any
 }
 
+export interface ModulePublicRuntimeConfig {
+  NAME: string
+}
+
+export interface ModulePrivateRuntimeConfig {
+  PRIVATE_NAME: string
+}
+
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'my-module',

--- a/example/src/module.ts
+++ b/example/src/module.ts
@@ -12,7 +12,7 @@ export interface ModulePublicRuntimeConfig {
   NAME: string
 }
 
-export interface ModulePrivateRuntimeConfig {
+export interface ModuleRuntimeConfig {
   PRIVATE_NAME: string
 }
 

--- a/example/src/module.ts
+++ b/example/src/module.ts
@@ -8,6 +8,14 @@ export interface ModuleHooks {
   'my-module:init': any
 }
 
+export interface ModulePublicRuntimeConfig {
+  NAME: string
+}
+
+export interface ModulePrivateRuntimeConfig {
+  PRIVATE_NAME: string
+}
+
 export default defineNuxtModule<ModuleOptions>({
   meta: {
     name: 'my-module',

--- a/src/build.ts
+++ b/src/build.ts
@@ -93,7 +93,7 @@ async function writeTypes (distDir: string, meta: ModuleMeta) {
   const moduleImports = []
   const moduleImportKeys = [
     { key: 'ModuleOptions', interfaces: ['NuxtConfig', 'NuxtOptions'] },
-    { key: 'ModuleHooks', interfaces: ['ModuleHooks'] },
+    { key: 'ModuleHooks', interfaces: ['NuxtHooks'] },
     { key: 'ModuleRuntimeConfig', interfaces: ['RuntimeConfig'] },
     { key: 'ModulePublicRuntimeConfig', interfaces: ['PublicRuntimeConfig'] }
   ]

--- a/src/build.ts
+++ b/src/build.ts
@@ -93,8 +93,8 @@ async function writeTypes (distDir: string, meta: ModuleMeta) {
   const moduleImportKeys = [
     { key: 'ModuleOptions', interfaces: ['NuxtConfig', 'NuxtOptions'] },
     { key: 'ModuleHooks', interfaces: ['ModuleHooks'] },
-    { key: 'ModulePublicRuntimeConfig', interfaces: ['PublicRuntimeConfig'] },
-    { key: 'ModulePrivateRuntimeConfig', interfaces: ['PrivateRuntimeConfig'] }
+    { key: 'ModuleRuntimeConfig', interfaces: ['RuntimeConfig'] },
+    { key: 'ModulePublicRuntimeConfig', interfaces: ['PublicRuntimeConfig'] }
   ]
 
   // Generate schema shims


### PR DESCRIPTION
# Context

Fixes: #24 

Wanted to help drive the auto generation of the specs for Private & Public runtime configs 

# Example

<img width="1051" alt="image" src="https://user-images.githubusercontent.com/6619884/190520399-af41429f-e935-4afb-9562-01f2f5e396fe.png">
