### PR TITLE
chore: add repository field to `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@nuxt/module-builder",
   "version": "0.3.1",
+  "repository": "nuxt/module-builder",
   "description": "Complete solution to build Nuxt Modules",
   "license": "MIT",
   "type": "module",


### PR DESCRIPTION
Allow package manager website catalogs to link to the repository.