### PR TITLE
chore: update node to v20

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ We recommend to checkout the [Nuxt modules author guide](https://nuxt.com/docs/g
 ## Requirements
 
 For a user to use a module generated from module-builder, it's recommended they have:
-- Node.js >= 14.x. _Latest Node LTS preferred_
+- Node.js >= 16.x. _Latest Node LTS preferred_
 - Nuxt 3 or Nuxt Bridge. _Nuxt 2 is functional but not advised_
 
 ## Quick start
@@ -133,7 +133,7 @@ Module builder generates dist files in `dist/` directory:
 ## 💻 Development
 
 - Clone repository
-- Enable [Corepack](https://github.com/nodejs/corepack) using `corepack enable` (use `npm i -g corepack` for Node.js < 16.10)
+- Enable [Corepack](https://github.com/nodejs/corepack) using `corepack enable`
 - Install dependencies using `pnpm install`
 - Try building [example module](./example) using `pnpm example:build`
 
@@ -151,4 +151,3 @@ Module builder generates dist files in `dist/` directory:
 
 [license-src]: https://img.shields.io/github/license/nuxt/module-builder.svg?style=flat&colorA=18181B&colorB=28CF8D
 [license-href]: https://github.com/nuxt/module-builder/blob/main/LICENSE
-

--- a/example/package.json
+++ b/example/package.json
@@ -26,7 +26,7 @@
     "@nuxt/kit": "^3.4.3"
   },
   "devDependencies": {
-    "@types/node": "^18.16.8",
+    "@types/node": "^20.1.3",
     "@nuxt/module-builder": "workspace:*",
     "@nuxt/schema": "^3.4.3",
     "nuxt": "^3.4.3"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@nuxt/schema": "^3.4.3",
     "@nuxtjs/eslint-config-typescript": "^12.0.0",
     "@types/mri": "^1.1.1",
-    "@types/node": "^18.16.8",
+    "@types/node": "^20.1.3",
     "@vitest/coverage-c8": "^0.31.0",
     "eslint": "^8.40.0",
     "jiti": "^1.18.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -33,8 +33,8 @@ importers:
         specifier: ^1.1.1
         version: 1.1.1
       '@types/node':
-        specifier: ^18.16.8
-        version: 18.16.8
+        specifier: ^20.1.3
+        version: 20.1.3
       '@vitest/coverage-c8':
         specifier: ^0.31.0
         version: 0.31.0(vitest@0.31.0)
@@ -46,7 +46,7 @@ importers:
         version: 1.18.2
       nuxt:
         specifier: ^3.4.3
-        version: 3.4.3(@types/node@18.16.8)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4)
+        version: 3.4.3(@types/node@20.1.3)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4)
       standard-version:
         specifier: ^9.5.0
         version: 9.5.0
@@ -67,11 +67,11 @@ importers:
         specifier: ^3.4.3
         version: 3.4.3(rollup@3.21.5)
       '@types/node':
-        specifier: ^18.16.8
-        version: 18.16.8
+        specifier: ^20.1.3
+        version: 20.1.3
       nuxt:
         specifier: ^3.4.3
-        version: 3.4.3(@types/node@18.16.8)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4)
+        version: 3.4.3(@types/node@20.1.3)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4)
 
   example/playground:
     dependencies:
@@ -80,7 +80,7 @@ importers:
         version: link:..
       nuxt:
         specifier: latest
-        version: 3.4.3(@types/node@18.16.8)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4)
+        version: 3.4.3(@types/node@20.1.3)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4)
 
 packages:
 
@@ -761,7 +761,7 @@ packages:
   /@nuxt/ui-templates@1.1.1:
     resolution: {integrity: sha512-PjVETP7+iZXAs5Q8O4ivl4t6qjWZMZqwiTVogUXHoHGZZcw7GZW3u3tzfYfE1HbzyYJfr236IXqQ02MeR8Fz2w==}
 
-  /@nuxt/vite-builder@3.4.3(@types/node@18.16.8)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4)(vue@3.2.47):
+  /@nuxt/vite-builder@3.4.3(@types/node@20.1.3)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4)(vue@3.2.47):
     resolution: {integrity: sha512-60bXtjEILon0vJ8bC1cpZyV7GiCMlLiji/g/Q55mfsTYHH/1cgTG4UCodbGAZfDouZyyG8D4IrZ3lcizp3Zp9Q==}
     engines: {node: ^14.18.0 || >=16.10.0}
     peerDependencies:
@@ -797,8 +797,8 @@ packages:
       strip-literal: 1.0.1
       ufo: 1.1.2
       unplugin: 1.3.1
-      vite: 4.3.5(@types/node@18.16.8)
-      vite-node: 0.30.1(@types/node@18.16.8)
+      vite: 4.3.5(@types/node@20.1.3)
+      vite-node: 0.30.1(@types/node@20.1.3)
       vite-plugin-checker: 0.5.6(eslint@8.40.0)(typescript@5.0.4)(vite@4.3.5)
       vue: 3.2.47
       vue-bundle-renderer: 1.0.3
@@ -1040,8 +1040,8 @@ packages:
     resolution: {integrity: sha512-nJOuiTlsvmClSr3+a/trTSx4DTuY/VURsWGKSf/eeavh0LRMqdsK60ti0TlwM5iHiGOK3/Ibkxsbr7i9rzGreA==}
     dev: true
 
-  /@types/node@18.16.8:
-    resolution: {integrity: sha512-p0iAXcfWCOTCBbsExHIDFCfwsqFwBTgETJveKMT+Ci3LY9YqQCI91F5S+TB20+aRCXpcWfvx5Qr5EccnwCm2NA==}
+  /@types/node@20.1.3:
+    resolution: {integrity: sha512-NP2yfZpgmf2eDRPmgGq+fjGjSwFgYbihA8/gK+ey23qT9RkxsgNTZvGOEpXgzIGqesTYkElELLgtKoMQTys5vA==}
 
   /@types/normalize-package-data@2.4.1:
     resolution: {integrity: sha512-Gj7cI7z+98M282Tqmp2K5EIsoouUEzbBJhQQzDE3jSIRk6r9gsz0oUokqIUR4u1R3dMHo0pDHM7sNOHyhulypw==}
@@ -1248,7 +1248,7 @@ packages:
       '@babel/core': 7.21.8
       '@babel/plugin-transform-typescript': 7.21.3(@babel/core@7.21.8)
       '@vue/babel-plugin-jsx': 1.1.1(@babel/core@7.21.8)
-      vite: 4.3.5(@types/node@18.16.8)
+      vite: 4.3.5(@types/node@20.1.3)
       vue: 3.2.47
     transitivePeerDependencies:
       - supports-color
@@ -1260,7 +1260,7 @@ packages:
       vite: ^4.0.0
       vue: ^3.2.25
     dependencies:
-      vite: 4.3.5(@types/node@18.16.8)
+      vite: 4.3.5(@types/node@20.1.3)
       vue: 3.2.47
 
   /@vitest/coverage-c8@0.31.0(vitest@0.31.0):
@@ -4665,7 +4665,7 @@ packages:
     optionalDependencies:
       fsevents: 2.3.2
 
-  /nuxt@3.4.3(@types/node@18.16.8)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4):
+  /nuxt@3.4.3(@types/node@20.1.3)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4):
     resolution: {integrity: sha512-rOEdhHRH33m3L7aJDO7N8C+NC2vSa2mC/0hH/ePmg2S03qkzS0bVg1pIWW9ESDV5UVPFtfhOGoDTEkLJqvE18A==}
     engines: {node: ^14.18.0 || >=16.10.0}
     hasBin: true
@@ -4681,8 +4681,8 @@ packages:
       '@nuxt/schema': 3.4.3(rollup@3.21.5)
       '@nuxt/telemetry': 2.2.0(rollup@3.21.5)
       '@nuxt/ui-templates': 1.1.1
-      '@nuxt/vite-builder': 3.4.3(@types/node@18.16.8)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4)(vue@3.2.47)
-      '@types/node': 18.16.8
+      '@nuxt/vite-builder': 3.4.3(@types/node@20.1.3)(eslint@8.40.0)(rollup@3.21.5)(typescript@5.0.4)(vue@3.2.47)
+      '@types/node': 20.1.3
       '@unhead/ssr': 1.1.26
       '@unhead/vue': 1.1.26(vue@3.2.47)
       '@vue/shared': 3.2.47
@@ -6434,7 +6434,7 @@ packages:
       spdx-expression-parse: 3.0.1
     dev: true
 
-  /vite-node@0.30.1(@types/node@18.16.8):
+  /vite-node@0.30.1(@types/node@20.1.3):
     resolution: {integrity: sha512-vTikpU/J7e6LU/8iM3dzBo8ZhEiKZEKRznEMm+mJh95XhWaPrJQraT/QsT2NWmuEf+zgAoMe64PKT7hfZ1Njmg==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -6444,7 +6444,7 @@ packages:
       mlly: 1.2.1
       pathe: 1.1.0
       picocolors: 1.0.0
-      vite: 4.3.5(@types/node@18.16.8)
+      vite: 4.3.5(@types/node@20.1.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6454,7 +6454,7 @@ packages:
       - supports-color
       - terser
 
-  /vite-node@0.31.0(@types/node@18.16.8):
+  /vite-node@0.31.0(@types/node@20.1.3):
     resolution: {integrity: sha512-8x1x1LNuPvE2vIvkSB7c1mApX5oqlgsxzHQesYF7l5n1gKrEmrClIiZuOFbFDQcjLsmcWSwwmrWrcGWm9Fxc/g==}
     engines: {node: '>=v14.18.0'}
     hasBin: true
@@ -6464,7 +6464,7 @@ packages:
       mlly: 1.2.1
       pathe: 1.1.0
       picocolors: 1.0.0
-      vite: 4.3.5(@types/node@18.16.8)
+      vite: 4.3.5(@types/node@20.1.3)
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -6520,13 +6520,13 @@ packages:
       strip-ansi: 6.0.1
       tiny-invariant: 1.3.1
       typescript: 5.0.4
-      vite: 4.3.5(@types/node@18.16.8)
+      vite: 4.3.5(@types/node@20.1.3)
       vscode-languageclient: 7.0.0
       vscode-languageserver: 7.0.0
       vscode-languageserver-textdocument: 1.0.8
       vscode-uri: 3.0.7
 
-  /vite@4.3.5(@types/node@18.16.8):
+  /vite@4.3.5(@types/node@20.1.3):
     resolution: {integrity: sha512-0gEnL9wiRFxgz40o/i/eTBwm+NEbpUeTWhzKrZDSdKm6nplj+z4lKz8ANDgildxHm47Vg8EUia0aicKbawUVVA==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
@@ -6551,7 +6551,7 @@ packages:
       terser:
         optional: true
     dependencies:
-      '@types/node': 18.16.8
+      '@types/node': 20.1.3
       esbuild: 0.17.18
       postcss: 8.4.23
       rollup: 3.21.5
@@ -6591,7 +6591,7 @@ packages:
     dependencies:
       '@types/chai': 4.3.5
       '@types/chai-subset': 1.3.3
-      '@types/node': 18.16.8
+      '@types/node': 20.1.3
       '@vitest/expect': 0.31.0
       '@vitest/runner': 0.31.0
       '@vitest/snapshot': 0.31.0
@@ -6611,8 +6611,8 @@ packages:
       strip-literal: 1.0.1
       tinybench: 2.5.0
       tinypool: 0.5.0
-      vite: 4.3.5(@types/node@18.16.8)
-      vite-node: 0.31.0(@types/node@18.16.8)
+      vite: 4.3.5(@types/node@20.1.3)
+      vite-node: 0.31.0(@types/node@20.1.3)
       why-is-node-running: 2.2.2
     transitivePeerDependencies:
       - less


### PR DESCRIPTION
Also, update the readme so that node 16 is the minimum version mentioned, removing corepack installation instructions for versions lower then 16.