### PR TITLE
chore: use consola's named export

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -1,7 +1,7 @@
 import { existsSync, promises as fsp } from 'fs'
 import { pathToFileURL } from 'url'
 import { resolve } from 'pathe'
-import consola from 'consola'
+import { consola } from 'consola'
 import type { ModuleMeta, NuxtModule } from '@nuxt/schema'
 import { findExports } from 'mlly'
 


### PR DESCRIPTION
Resolves a linter warning.