### PR TITLE
feat: support `--sourcemap` option

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -7,6 +7,7 @@ import { findExports } from 'mlly'
 
 export interface BuildModuleOptions {
   rootDir: string
+  sourcemap?: boolean
   stub?: boolean
   outDir?: string
 }
@@ -18,6 +19,7 @@ export async function buildModule (opts: BuildModuleOptions) {
 
   await build(opts.rootDir, false, {
     declaration: true,
+    sourcemap: opts.sourcemap,
     stub: opts.stub,
     outDir,
     entries: [

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ function main () {
   return buildModule({
     rootDir: resolve(args._[0] || '.'),
     outDir: args.outDir,
+    sourcemap: args.sourcemap,
     stub: args.stub
   })
 }


### PR DESCRIPTION
Add the `--sourcemap` option to generate sourcemaps, which could help when using a debugger.