### PR TITLE
fix: esnext-compatible output

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -48,6 +48,9 @@ export default defineCommand({
         { input: 'src/runtime/', outDir: `${outDir}/runtime`, ext: 'mjs' }
       ],
       rollup: {
+        esbuild: {
+          target: 'esnext'
+        },
         emitCJS: false,
         cjsBridge: true
       },


### PR DESCRIPTION
https://github.com/nuxt-modules/icon/commit/3ae9030480958b561582ef0c80d9e1a9fc3307dc

otherwise we end up stripping out import assertions.

@pi0 - do you think we should have this as a default directly in unbuild instead?