### PR TITLE
feat: support writing `RuntimeNuxtHooks` types

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The entrypoint for module definition.
 
 A default export using `defineNuxtModule` and `ModuleOptions` type export is expected.
 
-You could also optionally export `ModuleHooks` to annotate any custom hooks the module uses.
+You could also optionally export `ModuleHooks` or `RuntimeModuleHooks` to annotate any custom hooks the module uses.
 
 ```ts [src/module.ts]
 import { defineNuxtModule } from '@nuxt/kit'
@@ -53,6 +53,10 @@ export interface ModuleOptions {
 
 export interface ModuleHooks {
   'my-module:init': any
+}
+
+export interface RuntimeModuleHooks {
+  'my-module:runtime-hook': any
 }
 
 export interface ModulePublicRuntimeConfig {

--- a/example/src/module.ts
+++ b/example/src/module.ts
@@ -9,6 +9,10 @@ export interface ModuleHooks {
   'my-module:init': any
 }
 
+export interface RuntimeModuleHooks {
+  'my-module:runtime-hook': any
+}
+
 export interface ModulePublicRuntimeConfig {
   NAME: string
 }

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -126,6 +126,7 @@ async function writeTypes (distDir: string, meta: ModuleMeta) {
   )
   const isStub = moduleTypes.includes('export *')
 
+  const appShims = []
   const schemaShims = []
   const moduleImports = []
 
@@ -140,6 +141,10 @@ async function writeTypes (distDir: string, meta: ModuleMeta) {
     moduleImports.push('ModuleHooks')
     schemaShims.push('  interface NuxtHooks extends ModuleHooks {}')
   }
+  if (hasTypeExport('RuntimeModuleHooks')) {
+    moduleImports.push('RuntimeModuleHooks')
+    appShims.push('  interface RuntimeNuxtHooks extends RuntimeModuleHooks {}')
+  }
   if (hasTypeExport('ModuleRuntimeConfig')) {
     moduleImports.push('ModuleRuntimeConfig')
     schemaShims.push('  interface RuntimeConfig extends ModuleRuntimeConfig {}')
@@ -152,6 +157,7 @@ async function writeTypes (distDir: string, meta: ModuleMeta) {
   const dtsContents = `
 import { ${moduleImports.join(', ')} } from './module'
 
+${appShims.length ? `declare module '#app' {\n${appShims.join('\n')}\n}\n` : ''}
 ${schemaShims.length ? `declare module '@nuxt/schema' {\n${schemaShims.join('\n')}\n}\n` : ''}
 ${schemaShims.length ? `declare module 'nuxt/schema' {\n${schemaShims.join('\n')}\n}\n` : ''}
 

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -45,7 +45,11 @@ describe('module builder', () => {
     const types = await readFile(join(distDir, 'types.d.ts'), 'utf-8')
     expect(types).toMatchInlineSnapshot(`
       "
-      import { ModuleOptions, ModuleHooks, ModuleRuntimeConfig, ModulePublicRuntimeConfig } from './module'
+      import { ModuleOptions, ModuleHooks, RuntimeModuleHooks, ModuleRuntimeConfig, ModulePublicRuntimeConfig } from './module'
+
+      declare module '#app' {
+        interface RuntimeNuxtHooks extends RuntimeModuleHooks {}
+      }
 
       declare module '@nuxt/schema' {
         interface NuxtConfig { ['myModule']?: Partial<ModuleOptions> }
@@ -64,7 +68,7 @@ describe('module builder', () => {
       }
 
 
-      export { ModuleHooks, ModuleOptions, ModulePublicRuntimeConfig, ModuleRuntimeConfig, default } from './module'
+      export { ModuleHooks, ModuleOptions, ModulePublicRuntimeConfig, ModuleRuntimeConfig, RuntimeModuleHooks, default } from './module'
       "
     `)
   })


### PR DESCRIPTION
Let me know if this is the correct approach, the documentation for typing [lifecycle hooks](https://nuxt.com/docs/guide/going-further/hooks#additional-hooks) differ from the generated types, but using `declare module '#app'` for both hook types didn't work for me locally (in `@nuxtjs/i18n`).

Also, shouldn't the generated types use the `verbatimModuleSyntax` as of Nuxt `3.8.0`?