### PR TITLE
fix: wrong Nuxt hooks module name

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ types
 package-lock.json
 .nuxt
 .output
+.idea

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,2 @@
 shamefully-hoist=true
+shell-emulator=true

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -157,7 +157,7 @@ async function writeTypes (distDir: string, meta: ModuleMeta) {
   const dtsContents = `
 import type { ${moduleImports.join(', ')} } from './module'
 
-${appShims.length ? `declare module '#app' {\n${appShims.join('\n')}\n}\n` : ''}
+${appShims.length ? `declare module '#app/nuxt' {\n${appShims.join('\n')}\n}\n` : ''}
 ${schemaShims.length ? `declare module '@nuxt/schema' {\n${schemaShims.join('\n')}\n}\n` : ''}
 ${schemaShims.length ? `declare module 'nuxt/schema' {\n${schemaShims.join('\n')}\n}\n` : ''}
 

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -47,7 +47,7 @@ describe('module builder', () => {
       "
       import type { ModuleOptions, ModuleHooks, RuntimeModuleHooks, ModuleRuntimeConfig, ModulePublicRuntimeConfig } from './module'
 
-      declare module '#app' {
+      declare module '#app/nuxt' {
         interface RuntimeNuxtHooks extends RuntimeModuleHooks {}
       }
 


### PR DESCRIPTION
This PR also includes:
- add `shell-emulator=true` in `.npmrc`: running test script on Windows fails
- include `.idea` folder (JetBrains IDE) in `.gitignore`

resolves #187