### PR TITLE
fix: `RuntimeModuleHooks` should be `ModuleRuntimeHooks`

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The entrypoint for module definition.
 
 A default export using `defineNuxtModule` and `ModuleOptions` type export is expected.
 
-You could also optionally export `ModuleHooks` or `RuntimeModuleHooks` to annotate any custom hooks the module uses.
+You could also optionally export `ModuleHooks` or `ModuleRuntimeHooks` to annotate any custom hooks the module uses.
 
 ```ts [src/module.ts]
 import { defineNuxtModule } from '@nuxt/kit'
@@ -55,8 +55,12 @@ export interface ModuleHooks {
   'my-module:init': any
 }
 
-export interface RuntimeModuleHooks {
+export interface ModuleRuntimeHooks {
   'my-module:runtime-hook': any
+}
+
+export interface ModuleRuntimeConfig {
+  PRIVATE_NAME: string
 }
 
 export interface ModulePublicRuntimeConfig {
@@ -140,7 +144,6 @@ Module builder generates dist files in `dist/` directory:
 ## License
 
 [MIT](./LICENSE) - Made with 💚
-
 
 <!-- Badges -->
 [npm-version-src]: https://img.shields.io/npm/v/@nuxt/module-builder/latest.svg?style=flat&colorA=18181B&colorB=28CF8D

--- a/example/src/module.ts
+++ b/example/src/module.ts
@@ -14,7 +14,7 @@ export interface ModuleRuntimeHooks {
 }
 
 /**
- * @deprecated Misspelling will be removed in the future
+ * @deprecated `RuntimeModuleHooks` is a deprecated naming and will be removed in the future. Please use `ModuleRuntimeHooks` instead.
  */
 export interface RuntimeModuleHooks {
   'my-module:runtime-hook': () => void

--- a/example/src/module.ts
+++ b/example/src/module.ts
@@ -9,6 +9,13 @@ export interface ModuleHooks {
   'my-module:init': () => void
 }
 
+export interface ModuleRuntimeHooks {
+  'my-module:runtime-hook': any
+}
+
+/**
+ * @deprecated Misspelling will be removed in the future
+ */
 export interface RuntimeModuleHooks {
   'my-module:runtime-hook': () => void
 }

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -141,15 +141,22 @@ async function writeTypes (distDir: string, meta: ModuleMeta) {
     moduleImports.push('ModuleHooks')
     schemaShims.push('  interface NuxtHooks extends ModuleHooks {}')
   }
-  if (hasTypeExport('RuntimeModuleHooks')) {
-    consola.warn('Please use \'ModuleRuntimeHooks\' instead of \'RuntimeModuleHooks\' as this misspelling will be removed in the future.')
-    moduleImports.push('RuntimeModuleHooks')
-    appShims.push('  interface RuntimeNuxtHooks extends RuntimeModuleHooks {}')
+
+  if (hasTypeExport('RuntimeModuleHooks') || hasTypeExport('ModuleRuntimeHooks')) {
+    const runtimeHooksInterfaces = []
+
+    if (hasTypeExport('RuntimeModuleHooks')) {
+      consola.warn('Please use \'ModuleRuntimeHooks\' instead of \'RuntimeModuleHooks\' as this misspelling will be removed in the future.')
+      runtimeHooksInterfaces.push('RuntimeModuleHooks')
+    }
+    if (hasTypeExport('ModuleRuntimeHooks')) {
+      runtimeHooksInterfaces.push('ModuleRuntimeHooks')
+    }
+
+    moduleImports.push(...runtimeHooksInterfaces)
+    appShims.push(`  interface RuntimeNuxtHooks extends ${runtimeHooksInterfaces.join(', ')} {}`)
   }
-  if (hasTypeExport('ModuleRuntimeHooks')) {
-    moduleImports.push('ModuleRuntimeHooks')
-    appShims.push('  interface RuntimeNuxtHooks extends ModuleRuntimeHooks {}')
-  }
+
   if (hasTypeExport('ModuleRuntimeConfig')) {
     moduleImports.push('ModuleRuntimeConfig')
     schemaShims.push('  interface RuntimeConfig extends ModuleRuntimeConfig {}')

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -146,7 +146,7 @@ async function writeTypes (distDir: string, meta: ModuleMeta) {
     const runtimeHooksInterfaces = []
 
     if (hasTypeExport('RuntimeModuleHooks')) {
-      consola.warn('Please use \'ModuleRuntimeHooks\' instead of \'RuntimeModuleHooks\' as this misspelling will be removed in the future.')
+      consola.warn('`RuntimeModuleHooks` is a deprecated naming and will be removed in the future. Please use `ModuleRuntimeHooks` instead.')
       runtimeHooksInterfaces.push('RuntimeModuleHooks')
     }
     if (hasTypeExport('ModuleRuntimeHooks')) {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -142,8 +142,13 @@ async function writeTypes (distDir: string, meta: ModuleMeta) {
     schemaShims.push('  interface NuxtHooks extends ModuleHooks {}')
   }
   if (hasTypeExport('RuntimeModuleHooks')) {
+    consola.warn('Please use \'ModuleRuntimeHooks\' instead of \'RuntimeModuleHooks\' as this misspelling will be removed in the future.')
     moduleImports.push('RuntimeModuleHooks')
     appShims.push('  interface RuntimeNuxtHooks extends RuntimeModuleHooks {}')
+  }
+  if (hasTypeExport('ModuleRuntimeHooks')) {
+    moduleImports.push('ModuleRuntimeHooks')
+    appShims.push('  interface RuntimeNuxtHooks extends ModuleRuntimeHooks {}')
   }
   if (hasTypeExport('ModuleRuntimeConfig')) {
     moduleImports.push('ModuleRuntimeConfig')

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -48,8 +48,7 @@ describe('module builder', () => {
       import type { ModuleOptions, ModuleHooks, RuntimeModuleHooks, ModuleRuntimeHooks, ModuleRuntimeConfig, ModulePublicRuntimeConfig } from './module'
 
       declare module '#app' {
-        interface RuntimeNuxtHooks extends RuntimeModuleHooks {}
-        interface RuntimeNuxtHooks extends ModuleRuntimeHooks {}
+        interface RuntimeNuxtHooks extends RuntimeModuleHooks, ModuleRuntimeHooks {}
       }
 
       declare module '@nuxt/schema' {

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -45,10 +45,11 @@ describe('module builder', () => {
     const types = await readFile(join(distDir, 'types.d.ts'), 'utf-8')
     expect(types).toMatchInlineSnapshot(`
       "
-      import type { ModuleOptions, ModuleHooks, RuntimeModuleHooks, ModuleRuntimeConfig, ModulePublicRuntimeConfig } from './module'
+      import type { ModuleOptions, ModuleHooks, RuntimeModuleHooks, ModuleRuntimeHooks, ModuleRuntimeConfig, ModulePublicRuntimeConfig } from './module'
 
       declare module '#app' {
         interface RuntimeNuxtHooks extends RuntimeModuleHooks {}
+        interface RuntimeNuxtHooks extends ModuleRuntimeHooks {}
       }
 
       declare module '@nuxt/schema' {
@@ -68,7 +69,7 @@ describe('module builder', () => {
       }
 
 
-      export type { ModuleHooks, ModuleOptions, ModulePublicRuntimeConfig, ModuleRuntimeConfig, RuntimeModuleHooks, default } from './module'
+      export type { ModuleHooks, ModuleOptions, ModulePublicRuntimeConfig, ModuleRuntimeConfig, ModuleRuntimeHooks, RuntimeModuleHooks, default } from './module'
       "
     `)
   })


### PR DESCRIPTION
Can't believe I wrote `RuntimeModuleHooks` instead of `ModuleRuntimeHooks` in #183 😭 I added a deprecation warning, and kept the previous way working, let me know if this should be different or removed!

The previous code was not broken, but I feel like the code looks off
```ts
interface ModuleOptions {}
interface ModuleHooks {}
interface RuntimeModuleHooks {}
interface ModuleRuntimeConfig {}
interface ModulePublicRuntimeConfig {}
```

vs 

```ts
interface ModuleOptions {}
interface ModuleHooks {}
interface ModuleRuntimeHooks {}
interface ModuleRuntimeConfig {}
interface ModulePublicRuntimeConfig {}
```
