### PR TITLE
fix: package types

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -8,10 +8,21 @@
       "types": "./dist/types.d.mts",
       "default": "./dist/module.mjs"
     },
-    "./utils": "./dist/utils.mjs"
+    "./utils": {
+      "types": "./dist/utils.d.mts",
+      "default": "./dist/utils.mjs"
+    }
   },
-  "main": "./dist/module.cjs",
-  "types": "./dist/types.d.ts",
+  "main": "dist/module.mjs",
+  "types": "dist/types.d.ts",
+  "typesVersions": {
+    "*": {
+      "*": [
+        "./dist/*",
+        "./*"
+      ]
+    }
+  },
   "files": [
     "dist"
   ],

--- a/example/package.json
+++ b/example/package.json
@@ -8,10 +8,7 @@
       "types": "./dist/types.d.mts",
       "default": "./dist/module.mjs"
     },
-    "./utils": {
-      "types": "./dist/utils.d.mts",
-      "default": "./dist/utils.mjs"
-    }
+    "./utils": "./dist/utils.mjs"
   },
   "main": "dist/module.mjs",
   "types": "dist/types.d.ts",

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -166,7 +166,7 @@ export type { ${typeExports[0].names.join(', ')} } from './module'
 
   await fsp.writeFile(dtsFile, dtsContents, 'utf8')
   if (!existsSync(dtsFileMts)) {
-    await fsp.writeFile(dtsFileMts, dtsContents, 'utf8')
+    await fsp.writeFile(dtsFileMts, dtsContents.replaceAll('./module', './module.js'), 'utf8')
   }
 }
 


### PR DESCRIPTION
This PR includes:
- use `./module.js` in `types.d.mts` generation
- move example to ESM-only

![imagen](https://github.com/nuxt/module-builder/assets/6311119/f1c1abf2-523a-46dc-baac-b3af67305dca)
