### PR TITLE
fix: load non relative tsconfig

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -247,13 +247,13 @@ function resolveTSCompilerExtends(extended, from) {
   let error
   try {
     return req.resolve(extended)
-	} catch (e) {
+  } catch (e) {
     error = e
   }
 
   if (extended[0] !== '.' && !isAbsolute(extended)) {
     return req.resolve(`${extended}/tsconfig.json`)
-	}
+  }
 
   throw error
 }

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -241,17 +241,17 @@ async function loadTSCompilerOptions(path: string): Promise<NonNullable<TSConfig
 
 function resolveTSCompilerExtends(extended, from) {
   // see https://github.com/dominikg/tsconfck/issues/149
-	if (extended === '..') extended = '../tsconfig.json'
-	const req = createRequire(from)
+  if (extended === '..') extended = '../tsconfig.json'
+  const req = createRequire(from)
 
   let error
-	try {
-		return req.resolve(extended)
+  try {
+    return req.resolve(extended)
 	} catch (e) {
     error = e
   }
 
-	if (extended[0] !== '.' && !isAbsolute(extended)) {
+  if (extended[0] !== '.' && !isAbsolute(extended)) {
     return req.resolve(`${extended}/tsconfig.json`)
 	}
 


### PR DESCRIPTION
fixes #267 (at least in some cases)

Currently, the `loadTSCompilerOptions` method does not handle correctly `tsconfig.json` `"extends"` field when it contains reference to an npm package.

Examples of such `"extends"`:
`"extends": "@something/my-config/tsconfig.json"`
`"extends": "@something/my-config/base.json"`
`"extends": "@something/my-config"`

With this change the script handles those cases correctly and (at least for me) fixes issue #267 