### PR TITLE
fix: do not augment nuxt options inside module entry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ package-lock.json
 .output
 .idea/
 example/playground/.nuxtrc
+.temp*

--- a/package.json
+++ b/package.json
@@ -40,8 +40,7 @@
     "pathe": "^1.1.2",
     "pkg-types": "^1.1.1",
     "tsconfck": "^3.1.0",
-    "unbuild": "^2.0.0",
-    "untyped": "^1.4.2"
+    "unbuild": "^2.0.0"
   },
   "peerDependencies": {
     "@nuxt/kit": "^3.12.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -40,9 +40,6 @@ importers:
       unbuild:
         specifier: ^2.0.0
         version: 2.0.0(typescript@5.4.5)(vue-tsc@2.0.19(typescript@5.4.5))
-      untyped:
-        specifier: ^1.4.2
-        version: 1.4.2
     devDependencies:
       '@nuxt/eslint-config':
         specifier: ^0.3.13

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -217,7 +217,7 @@ async function writeTypes(distDir: string, meta: ModuleMeta, getOptions: () => P
   if (!hasTypeExport('ModuleOptions')) {
     schemaImports.push('NuxtModule')
     moduleImports.push('default as Module')
-    moduleExports.push(`export type ModuleOptions = Module extends NuxtModule<infer O> ? Partial<O> : Record<string, any>`)
+    moduleExports.push(`export type ModuleOptions = typeof Module extends NuxtModule<infer O> ? Partial<O> : Record<string, any>`)
   }
 
   if (hasTypeExport('ModuleHooks')) {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -8,10 +8,9 @@ import type { TSConfig } from 'pkg-types'
 import { defu } from 'defu'
 import { anyOf, createRegExp } from 'magic-regexp'
 import { consola } from 'consola'
-import type { ModuleMeta, NuxtModule } from '@nuxt/schema'
+import type { NuxtModule } from '@nuxt/schema'
 import { findExports, resolvePath } from 'mlly'
 import { defineCommand } from 'citty'
-import { loadNuxt } from '@nuxt/kit'
 
 import { name, version } from '../../package.json'
 
@@ -170,24 +169,14 @@ export default defineCommand({
           await fsp.writeFile(metaFile, JSON.stringify(moduleMeta, null, 2), 'utf8')
 
           // Generate types
-          await writeTypes(ctx.options.outDir, moduleMeta, async () => {
-            const nuxt = await loadNuxt({
-              cwd,
-              overrides: {
-                modules: [resolve(cwd, './src/module')],
-              },
-            })
-            const moduleOptions = await moduleFn.getOptions?.({}, nuxt) || {}
-            await nuxt.close()
-            return moduleOptions
-          })
+          await writeTypes(ctx.options.outDir)
         },
       },
     })
   },
 })
 
-async function writeTypes(distDir: string, meta: ModuleMeta, getOptions: () => Promise<Record<string, unknown>>) {
+async function writeTypes(distDir: string) {
   const dtsFile = resolve(distDir, 'types.d.ts')
   const dtsFileMts = resolve(distDir, 'types.d.mts')
   if (existsSync(dtsFile)) {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -255,7 +255,7 @@ ${schemaShims.length ? `declare module '@nuxt/schema' {\n${schemaShims.join('\n'
 ${schemaShims.length ? `declare module 'nuxt/schema' {\n${schemaShims.join('\n')}\n}\n` : ''}
 ${moduleExports.length ? `\n${moduleExports.join('\n')}` : ''}
 ${typeExports[0] ? `\nexport type { ${typeExports[0].names.join(', ')} } from './module'` : ''}
-`.trim().replace(/[\n\r]{3,}/g, '\n\n')
+`.trim().replace(/[\n\r]{3,}/g, '\n\n') + '\n'
 
   await fsp.writeFile(dtsFile, dtsContents, 'utf8')
   if (!existsSync(dtsFileMts)) {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -10,8 +10,6 @@ import { anyOf, createRegExp } from 'magic-regexp'
 import { consola } from 'consola'
 import type { ModuleMeta, NuxtModule } from '@nuxt/schema'
 import { findExports, resolvePath } from 'mlly'
-import { resolveSchema, generateTypes } from 'untyped'
-import type { InputObject } from 'untyped'
 import { defineCommand } from 'citty'
 import { loadNuxt } from '@nuxt/kit'
 

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import { cp, mkdir, readFile, readdir, rm, writeFile } from 'node:fs/promises'
-import { beforeAll, describe, it, expect, afterAll } from 'vitest'
+import { beforeAll, describe, it, expect } from 'vitest'
 import { execaCommand } from 'execa'
 import { readPackageJSON } from 'pkg-types'
 import { dirname, join } from 'pathe'
@@ -18,14 +18,14 @@ describe('module builder', () => {
     // Prepare second root directory without type export
     await mkdir(dirname(secondRootDir), { recursive: true })
     await rm(secondRootDir, { force: true, recursive: true })
-    await cp(rootDir, secondRootDir, { recursive: true})
+    await cp(rootDir, secondRootDir, { recursive: true })
     const moduleSrc = join(secondRootDir, 'src/module.ts')
     const contents = await readFile(moduleSrc, 'utf-8').then(r => r.replace('export interface ModuleOptions', 'interface ModuleOptions'))
     await writeFile(moduleSrc, contents)
 
     await Promise.all([
       execaCommand('pnpm dev:prepare', { cwd: rootDir }).then(() => execaCommand('pnpm prepack', { cwd: rootDir })),
-      execaCommand('pnpm dev:prepare', { cwd: secondRootDir }).then(() => execaCommand('pnpm prepack', { cwd: secondRootDir }))
+      execaCommand('pnpm dev:prepare', { cwd: secondRootDir }).then(() => execaCommand('pnpm prepack', { cwd: secondRootDir })),
     ])
   }, 120 * 1000)
 

--- a/test/build.spec.ts
+++ b/test/build.spec.ts
@@ -77,7 +77,8 @@ describe('module builder', () => {
         interface PublicRuntimeConfig extends ModulePublicRuntimeConfig {}
       }
 
-      export type { ModuleHooks, ModuleOptions, ModulePublicRuntimeConfig, ModuleRuntimeConfig, ModuleRuntimeHooks, default } from './module'"
+      export type { ModuleHooks, ModuleOptions, ModulePublicRuntimeConfig, ModuleRuntimeConfig, ModuleRuntimeHooks, default } from './module'
+      "
     `)
   })
 
@@ -104,9 +105,10 @@ describe('module builder', () => {
         interface PublicRuntimeConfig extends ModulePublicRuntimeConfig {}
       }
 
-      export type ModuleOptions = Module extends NuxtModule<infer O> ? Partial<O> : Record<string, any>
+      export type ModuleOptions = typeof Module extends NuxtModule<infer O> ? Partial<O> : Record<string, any>
 
-      export type { ModuleHooks, ModulePublicRuntimeConfig, ModuleRuntimeConfig, ModuleRuntimeHooks, default } from './module'"
+      export type { ModuleHooks, ModulePublicRuntimeConfig, ModuleRuntimeConfig, ModuleRuntimeHooks, default } from './module'
+      "
     `)
   })
 


### PR DESCRIPTION
This relies on the Nuxt augmentation here instead:

https://github.com/nuxt/nuxt/blob/460d205edd24b280daae6b0dea45b3e9504d653e/packages/nuxt/src/core/templates.ts#L157-L215

this reverts https://github.com/nuxt/module-builder/pull/33