### PR TITLE
perf: removed unnecessary hasTypeExport check

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -217,9 +217,8 @@ async function writeTypes(distDir: string, isStub: boolean) {
   }
 
   if (hasTypeExport('ModuleRuntimeHooks')) {
-    const runtimeHooksInterfaces: string[] = ['ModuleRuntimeHooks']
-    moduleImports.push(...runtimeHooksInterfaces)
-    appShims.push(`  interface RuntimeNuxtHooks extends ${runtimeHooksInterfaces.join(', ')} {}`)
+    moduleImports.push('ModuleRuntimeHooks')
+    appShims.push(`  interface RuntimeNuxtHooks extends ModuleRuntimeHooks {}`)
   }
 
   if (hasTypeExport('ModuleRuntimeConfig')) {

--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -217,12 +217,7 @@ async function writeTypes(distDir: string, isStub: boolean) {
   }
 
   if (hasTypeExport('ModuleRuntimeHooks')) {
-    const runtimeHooksInterfaces: string[] = []
-
-    if (hasTypeExport('ModuleRuntimeHooks')) {
-      runtimeHooksInterfaces.push('ModuleRuntimeHooks')
-    }
-
+    const runtimeHooksInterfaces: string[] = ['ModuleRuntimeHooks']
     moduleImports.push(...runtimeHooksInterfaces)
     appShims.push(`  interface RuntimeNuxtHooks extends ${runtimeHooksInterfaces.join(', ')} {}`)
   }


### PR DESCRIPTION
I noticed the `hasTypeExport` check was being called twice when writing types in the build command.

This small change removes the additional call.