### PR TITLE
fix: prevent `undefined` error in `hasTypeExport`

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -203,7 +203,7 @@ async function writeTypes(distDir: string, isStub: boolean) {
   const schemaImports: string[] = []
   const moduleExports: string[] = []
 
-  const hasTypeExport = (name: string) => isStub || moduleReExports.find(exp => exp.names.includes(name))
+  const hasTypeExport = (name: string) => isStub || moduleReExports.find(exp => exp.names?.includes(name))
 
   if (!hasTypeExport('ModuleOptions')) {
     schemaImports.push('NuxtModule')


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
Fixes https://github.com/nuxt/module-builder/issues/309

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`names` can be null with star exports. Upstream fix to improve ts: https://github.com/unjs/mlly/pull/273


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
