### PR TITLE
fix(build): preserve getOptions in CJS wrapper

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -258,6 +258,9 @@ async function writeCJSStub(distDir: string) {
 }
 const _meta = module.exports.meta = require('./module.json')
 module.exports.getMeta = () => Promise.resolve(_meta)
+module.exports.getOptions = function(...args) {
+  return import('./module.mjs').then(m => m.default.getOptions.call(this, ...args))
+}
 `
   await fsp.writeFile(cjsStubFile, cjsStub, 'utf8')
 }


### PR DESCRIPTION
Hello again @danielroe,

I started my day with a warning from `@nuxtjs/sitemap` about `@nuxtjs/i18n` options not being available.


![image](https://github.com/user-attachments/assets/42d4ecc5-95c4-446a-ab12-f1e76be9d168)


1. The warning originates from `@nuxtjs/sitemap` trying to access the options of `@nuxtjs/i18n` using `nuxtModule.getOptions`
2. While the ESM version of the module has the `getOptions` method (added by `defineNuxtModule`), it's lost in the CJS wrapper
3. This happens because the current CJS stub generation in `@nuxt/module-builder` only preserves `meta` and `getMeta`, but not `getOptions` (i guess)

More details : 

I investigated the warning and found its source in `@nuxtjs/sitemap` at https://github.com/nuxt-modules/sitemap/blob/main/src/module.ts#L219, which leads to https://github.com/nuxt-modules/sitemap/blob/f52cafd726e2c5a7ebf8f768eda5d0f9befac9cc/src/util/kit.ts#L37.

The issue occurs when `@nuxtjs/sitemap` tries to use `@nuxtjs/i18n` options: `nuxtModule.getOptions` is undefined (where `nuxtModule` is `@nuxtjs/i18n`), resulting in no return value from `nuxtModule.getOptions(inlineOptions, nuxt)`.

The root cause is in the module loading process at https://github.com/nuxt/nuxt/blob/7177e81442559fee574e9460b4d76a780bb98211/packages/kit/src/module/install.ts#L85, where `getOptions` is not being preserved in the CJS wrapper.

Looking at `module.cjs` from `@nuxtjs/i18n`, `getOptions` is indeed missing. I tested by manually adding it to my node_modules and it all work, no warning anymore from @nuxtjs/sitemap  : 

```
module.exports = function(...args) {
  return import('./module.mjs').then(m => m.default.call(this, ...args))
}
const _meta = module.exports.meta = require('./module.json')
module.exports.getMeta = () => Promise.resolve(_meta)
// Added getOptions preservation
module.exports.getOptions = function(...args) {
  return import('./module.mjs').then(m => m.default.getOptions.call(this, ...args))
}
```


I discovered that this part was implemented using this package, so here I am, proposing an update to build.ts.

I only started looking into this today, so there's a chance I might be mistaken. The issue might not be here and could be related to `@nuxtjs/i18n` or `@nuxtjs/sitemap`.

@harlan-zw , this might interest you. I'm using version `6.1.4` of `@nuxtjs/sitemap`