### PR TITLE
feat(build): ignore test + story files in `runtime/` directory

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -62,6 +62,11 @@ export default defineCommand({
           outDir: `${outDir}/runtime`,
           addRelativeDeclarationExtensions: true,
           ext: 'js',
+          pattern: [
+            '**',
+            '!**/*.stories.{js,cts,mts,ts,jsx,tsx}', // ignore storybook files
+            '!**/*.{spec,test}.{js,cts,mts,ts,jsx,tsx}', // ignore tests
+          ],
           esbuild: {
             jsxImportSource: 'vue',
             jsx: 'automatic',


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This updates the defaults to ignore test + story files in `runtime/` (https://github.com/nuxt/module-builder/issues/211).

It remains possible to customise the pattern via a hook (https://github.com/nuxt/module-builder/issues/211#issuecomment-2567640633):

```ts
'build:before'(context) {
    const mkdistEntry = context.options.entries.find(entry => entry.builder === 'mkdist')
    mkdistEntry.pattern = ['**/*.ts', '!**/*.test.ts']
},
```