### PR TITLE
feat(build): add support for type exports in module re-exports

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -10,7 +10,7 @@ import { createJiti } from 'jiti'
 import { anyOf, createRegExp } from 'magic-regexp'
 import { consola } from 'consola'
 import type { NuxtModule } from '@nuxt/schema'
-import { findExports, resolvePath } from 'mlly'
+import { findExports, resolvePath, findTypeExports } from 'mlly'
 import type { ESMExport } from 'mlly'
 import { defineCommand } from 'citty'
 import { convertCompilerOptionsFromJson } from 'typescript'
@@ -223,6 +223,9 @@ async function writeTypes(distDir: string, isStub: boolean) {
       .replace(/export\s*\{.*?\}/gs, match => match.replace(/\b(type|interface)\b/g, ''))
     for (const e of findExports(normalisedModuleTypes)) {
       moduleReExports.push(e)
+    }
+    for (const i of findTypeExports(normalisedModuleTypes)) {
+      moduleReExports.push(i)
     }
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In some cases they are displayed in the type total export field. export type can be like `export type { ....}` . In this case we need to support all of them.

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
