### PR TITLE
feat: add autoImport option to prepare command

### DIFF
--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -17,6 +17,11 @@ export default defineCommand({
       description: 'Root directory',
       required: false,
     },
+    autoImport: {
+      type: 'boolean',
+      description: 'Enable auto import',
+      default: false,
+    },
   },
   async run(context) {
     const { runCommand } = await import('@nuxt/cli')
@@ -30,7 +35,7 @@ export default defineCommand({
           builder: 'shared',
         },
         imports: {
-          autoImport: false,
+          autoImport: context.args.autoImport,
         },
         modules: [
           resolve(cwd, './src/module'),


### PR DESCRIPTION
I'm using a Nuxt module as a package in a monorepo without building it, and auto imports are working correctly even in the Nuxt module. This option is helpful for enabling type checking in the Nuxt module depending on auto import in such situation.