### PR TITLE
fix: cannot find module jiti when stub import fails

### DIFF
--- a/src/commands/build.ts
+++ b/src/commands/build.ts
@@ -151,8 +151,15 @@ export default defineCommand({
           })
         },
         async 'rollup:done'(ctx) {
-          // Load module meta
           const moduleEntryPath = resolve(ctx.options.outDir, 'module.mjs')
+
+          if (ctx.options.stub) {
+            // Replace relative import path with a resolved absolute path
+            const contents = await fsp.readFile(moduleEntryPath, 'utf8')
+            await fsp.writeFile(moduleEntryPath, contents.replace(/(?<=from\s")([^"]+)/g, m => resolve(ctx.options.outDir, m)), 'utf-8')
+          }
+
+          // Load module meta
           const moduleFn = await jiti.import<NuxtModule<Record<string, unknown>>>(pathToFileURL(moduleEntryPath).toString(), { default: true }).catch((err) => {
             consola.error(err)
             consola.error('Cannot load module. Please check dist:', moduleEntryPath)


### PR DESCRIPTION
### 🔗 Linked issue
* #642 
* #588
<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Resolves #642
Resolves #588

I'm sure there is a better way to solve this issue. 

I narrowed down the issue here https://github.com/nuxt/module-builder/issues/588#issuecomment-3072810778, basically if an error is thrown while importing the module natively, jiti will attempt to import it again, in this attempt it will error due to the relative import to jiti not resolving correctly which in turn hides the original error that was thrown.

Using jiti's `tryNative` option also seems to resolve this issue, but I'm not sure if it has other implications.


<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate, please help us reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->
