### PR TITLE
chore: migrate to pnpm v11

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:knip": "knip --exclude unresolved",
     "test:types": "vue-tsc --noEmit && pnpm -r test:types"
   },
-  "packageManager": "pnpm@10.33.4",
+  "packageManager": "pnpm@11.1.2",
   "dependencies": {
     "citty": "^0.2.2",
     "consola": "^3.4.2",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -11,6 +11,8 @@ overrides:
   vue: "^3.5.34"
   vue-tsc: "^3.2.8"
 
+shellEmulator: true
+
 allowBuilds:
   "@parcel/watcher": false
   esbuild: false

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,12 +2,6 @@ packages:
   - example
   - example/playground
 
-ignoredBuiltDependencies:
-  - '@parcel/watcher'
-  - esbuild
-  - unrs-resolver
-
-
 overrides:
   "@nuxt/kit": "~4.4.5"
   "@nuxt/module-builder": "workspace:*"
@@ -16,3 +10,8 @@ overrides:
   typescript: "~5.9.3"
   vue: "^3.5.34"
   vue-tsc: "^3.2.8"
+
+allowBuilds:
+  "@parcel/watcher": false
+  esbuild: false
+  unrs-resolver: false


### PR DESCRIPTION
### 📚 Description

this migrates us to pnpm v11, and - in particular - to moving to `allowBuilds`