### PR TITLE
fix: fix runtime path in typescript config

### DIFF
--- a/example/src/runtime/server/plugins/plugin.ts
+++ b/example/src/runtime/server/plugins/plugin.ts
@@ -1,0 +1,1 @@
+export default defineNitroPlugin(() => {})

--- a/src/commands/prepare.ts
+++ b/src/commands/prepare.ts
@@ -26,7 +26,7 @@ export default defineCommand({
           autoImport: false,
         },
         modules: [
-          resolve(cwd, './src/module'),
+          resolve(cwd, './src'),
           function (_options, nuxt) {
             nuxt.hooks.hook('app:templates', (app) => {
               for (const template of app.templates) {

--- a/test/prepare.spec.ts
+++ b/test/prepare.spec.ts
@@ -1,0 +1,33 @@
+import { fileURLToPath } from 'node:url'
+import { cp, mkdir, readFile, rm } from 'node:fs/promises'
+import { beforeAll, describe, expect, it } from 'vitest'
+import { exec } from 'tinyexec'
+import { dirname, join } from 'pathe'
+
+describe('module builder', () => {
+  const workspaceDir = fileURLToPath(new URL('..', import.meta.url))
+  const exampleDir = fileURLToPath(new URL('../example', import.meta.url))
+  const prepareRootDir = exampleDir.replace('example', '.temp-example-prepare')
+
+  beforeAll(async () => {
+    await mkdir(dirname(prepareRootDir), { recursive: true })
+    await rm(prepareRootDir, { force: true, recursive: true })
+    await cp(exampleDir, prepareRootDir, { recursive: true })
+
+    await exec('pnpm', ['nuxt-module-build', 'prepare', prepareRootDir], {
+    nodeOptions: { cwd: workspaceDir },
+    })
+  }, 120 * 1000)
+
+  it('includes module runtime in generated server tsconfig', async () => {
+    const serverTsconfig = await readFile(join(prepareRootDir, '.nuxt/tsconfig.server.json'), 'utf-8')
+    const parsed = JSON.parse(serverTsconfig) as { include?: unknown }
+    const include = Array.isArray(parsed.include) ? parsed.include : []
+
+    expect(
+    include.some(
+        value => typeof value === 'string' && value.includes('../src/runtime'),
+    ),
+    ).toBe(true)
+  })
+})

--- a/test/prepare.spec.ts
+++ b/test/prepare.spec.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url'
-import { cp, mkdir, rm, writeFile } from 'node:fs/promises'
+import { cp, mkdir, rm } from 'node:fs/promises'
 import ts from 'typescript'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { exec } from 'tinyexec'

--- a/test/prepare.spec.ts
+++ b/test/prepare.spec.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url'
-import { cp, mkdir, readFile, rm } from 'node:fs/promises'
+import { cp, mkdir, rm, writeFile } from 'node:fs/promises'
+import ts from 'typescript'
 import { beforeAll, describe, expect, it } from 'vitest'
 import { exec } from 'tinyexec'
 import { dirname, join } from 'pathe'
@@ -15,19 +16,15 @@ describe('module builder', () => {
     await cp(exampleDir, prepareRootDir, { recursive: true })
 
     await exec('pnpm', ['nuxt-module-build', 'prepare', prepareRootDir], {
-    nodeOptions: { cwd: workspaceDir },
+      nodeOptions: { cwd: workspaceDir },
     })
   }, 120 * 1000)
 
-  it('includes module runtime in generated server tsconfig', async () => {
-    const serverTsconfig = await readFile(join(prepareRootDir, '.nuxt/tsconfig.server.json'), 'utf-8')
-    const parsed = JSON.parse(serverTsconfig) as { include?: unknown }
-    const include = Array.isArray(parsed.include) ? parsed.include : []
-
-    expect(
-    include.some(
-        value => typeof value === 'string' && value.includes('../src/runtime'),
-    ),
-    ).toBe(true)
+  it('includes runtime server plugin in resolved tsconfig files', async () => {
+    const serverTsconfigPath = join(prepareRootDir, '.nuxt/tsconfig.server.json')
+    const sourceFile = ts.readJsonConfigFile(serverTsconfigPath, ts.sys.readFile)
+    const parsed = ts.parseJsonSourceFileConfigFileContent(sourceFile, ts.sys, dirname(serverTsconfigPath))
+    const expectedPluginPath = join(prepareRootDir, 'src/runtime/server/plugins/plugin.ts')
+    expect(parsed.fileNames).toContain(expectedPluginPath)
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->
resolves #749

### 📚 Description

<!-- Describe your changes in detail. Why is this change required? What problem does it solve? -->

<!----------------------------------------------------------------------
Before creating the pull request, please make sure you do the following:

- Check that there isn't already a PR that solves the problem the same way. If you find a duplicate,
  please help us by reviewing it.
- Read the contribution docs at https://nuxt.com/docs/community/contribution
- Ensure that PR title follows conventional commits (https://www.conventionalcommits.org)
- Update the corresponding documentation if needed.
- Include relevant tests that fail without this PR but pass with it.

If you used AI tools to help with this contribution, please ensure the PR description and
code reflect your own understanding.

Write in your own voice rather than copying AI-generated text.

Thank you for contributing to Nuxt!
----------------------------------------------------------------------->

Looks like this is fixing the path in TypeScript and the build command still works. Tests are failing but they are also failing for me without the change. I added a test for that use case that runs through.

I'm not sure if we need to convert slashes when matching the path in the test since I'm usually using node:path, which uses OS-specific slashes.