### PR TITLE
chore: replace `latest` ranges with caret ranges

### DIFF
--- a/example/playground/package.json
+++ b/example/playground/package.json
@@ -6,7 +6,7 @@
   },
   "dependencies": {
     "my-module": "workspace:*",
-    "nuxt": "latest"
+    "nuxt": "^4.5.1"
   },
   "devDependencies": {
     "typescript": "^5.9.3",


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number. For example, "resolves #123" -->

### 📚 Description

`latest` is a curse and can easily drift, or change wildly on lockfile regeneration